### PR TITLE
added support for lifecycle rules in DSL

### DIFF
--- a/src/rulesets/api-lifeycle.ts
+++ b/src/rulesets/api-lifeycle.ts
@@ -1,0 +1,14 @@
+import { SnykApiCheckDsl } from '../dsl';
+const { expect } = require('chai');
+
+export const rules = {
+  example: ({ checkApiContext, responses }: SnykApiCheckDsl) => {
+    checkApiContext.must(
+      'lifeycle rules have to be followed',
+      (context, docs) => {
+        docs.includeDocsLink('https://how.we.version/rule');
+        context.changeVersion.date;
+      },
+    );
+  },
+};


### PR DESCRIPTION
Added Snyk specific context rules to the API DSL

```
checkApiContext.must(
      'lifeycle rules have to be followed',
      (context, docs) => {
        docs.includeDocsLink('https://how.we.version/rule');
        context.changeVersion.date; // must be X
      },
    );
```